### PR TITLE
修正placeholder样式的bug

### DIFF
--- a/yummy/client/src/components/Form/form.css
+++ b/yummy/client/src/components/Form/form.css
@@ -58,7 +58,7 @@
   outline: 0;
 }
 
-.form input:placeholder {
+.form input::placeholder {
   font-size: 12px;
   color: #878787;
 }


### PR DESCRIPTION
我确认过了，这个placeholder要双冒号，你可以改下字体大小试试就知道了，当冒号是无效的，双冒号生效了，用WebStorm也会报语法错误